### PR TITLE
add nodemon package and fix initial.js is_bot verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 .env
 *.log
 users.json
+package-lock.json
 .nvmrc
 .env.sample
 slush/*

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node src/index.js"
+    "start": "node src/index.js",
+    "dev": "nodemon src/index.js"
   },
   "author": "CodeBuddies <codebuddiesdotorg@gmail.com>",
   "dependencies": {
@@ -18,5 +19,8 @@
     "express": "^4.15.2",
     "node-json-db": "^0.7.3",
     "querystring": "^0.2.0"
+  },
+  "devDependencies": {
+    "nodemon": "^1.17.1"
   }
 }

--- a/src/app/routes/events/initial.js
+++ b/src/app/routes/events/initial.js
@@ -18,7 +18,7 @@ const eventWelcome = (req, res) => {
 
         // `team_join` is fired whenever a new user (incl. a bot) joins the team
         // check if `event.is_restricted == true` to limit to guest accounts
-        if (event.type === 'team_join' || !event.is_bot) {
+        if (event.type === 'team_join' && !event.user.is_bot) {
           const { team_id, id } = event.user;
           initialMessage(team_id, id);
         }


### PR DESCRIPTION
Added nodemon package to be able to see changes without starting over the server each time
Added package-lock.json in .gitignore
Changed `if (event.type === 'team_join' || !event.is_bot)` into `if (event.type === 'team_join' && !event.user.is_bot)` in src/app/routes/events/initial.js line 21 