### PR TITLE
Revert "Adding Dockerfile and docker-compose.test.yml for testing inside docker-cloud."

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM node:8-alpine
-WORKDIR /app
-ENV PORT=3000
-ADD package.json .
-ADD src ./src
-ADD test ./test
-RUN npm i
-
-CMD ["npm", "run", "start:dev"]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,3 +1,0 @@
-sut:
-  build: .
-  command: npm run test


### PR DESCRIPTION
Reverts codebuddies/greetbot#68 and removes Dockerfiles. 

Considering how greetbot is setup, the use of Docker and Dockercloud in this use case isn't very beneficial to us currently. It maybe down the line, but in the meantime, the less unused code we have in the code base the lower our technical debt is. 

--- 
The use case of Docker clould is as follows: 
 - Running Docker allows us to preview submitted PRs on a live link without having to check out the fork.

However, the counterpoint here is that due to how our staging environment for Slack is set up, we need  to connect Slack's API with a controlled server (in our case, a local tunnel URL). Due to how much work goes in integrating greetbot in a Slack channel already is, it would be a hinderance in having to set up greetbot every single time we want to preview a PR through docker in comparison to just pulling the PR locally. 